### PR TITLE
Fix option handling for select inputs in relative model

### DIFF
--- a/src/js/components/field/Field.js
+++ b/src/js/components/field/Field.js
@@ -14,6 +14,7 @@ import { FieldText, Label } from './styles'
 
 function Field(props) {
   const {
+    namespace,
     schema,
     value,
     errors,
@@ -39,6 +40,7 @@ function Field(props) {
         <FieldHelp help={schema.config.help} />
       </FieldText>
       <Input
+        namespace={namespace}
         schema={schema}
         value={value}
         errors={errors}
@@ -50,6 +52,7 @@ function Field(props) {
 }
 
 Field.propTypes = {
+  namespace: PropTypes.string,
   schema: PropTypes.object,
   value: PropTypes.any,
   errors: PropTypes.oneOfType([

--- a/src/js/components/has_many_input/HasManyInput.js
+++ b/src/js/components/has_many_input/HasManyInput.js
@@ -102,6 +102,7 @@ function HasManyInput(props) {
       {relatives.map((relative, i) => (
         <Relative
           key={relative.id}
+          namespace={`${schema.relative}-${relative.id}`}
           schema={relativeSchema}
           values={relative.relative}
           errors={relativeErrors.errors[i]}

--- a/src/js/components/has_many_input/Relative.js
+++ b/src/js/components/has_many_input/Relative.js
@@ -6,6 +6,7 @@ import UndoDelete from './UndoDelete'
 
 function Relative(props) {
   const {
+    namespace,
     schema,
     values,
     errors,
@@ -32,6 +33,7 @@ function Relative(props) {
           {schema.map((column, i) => (
             <Field
               key={column.id}
+              namespace={namespace}
               schema={column}
               value={values[i]}
               errors={errors[i]}
@@ -47,6 +49,7 @@ function Relative(props) {
 }
 
 Relative.propTypes = {
+  namespace: PropTypes.string,
   schema: PropTypes.array,
   values: PropTypes.array,
   errors: PropTypes.object,

--- a/src/js/components/select_input/ChoiceInput.js
+++ b/src/js/components/select_input/ChoiceInput.js
@@ -5,6 +5,7 @@ import { parseValue, serializeValue } from 'js/utils/serialize'
 
 function ChoiceInput(props) {
   const {
+    namespace,
     schema,
     value,
     setField,
@@ -44,7 +45,7 @@ function ChoiceInput(props) {
         return (
           <div key={i}>
             <Input
-              name={`select-${schema.id}`}
+              name={`${namespace}:select-${schema.id}`}
               checked={checked}
               onChange={() => handleChange(opt, checked)}
               onBlur={validateField}
@@ -61,6 +62,7 @@ function ChoiceInput(props) {
 }
 
 ChoiceInput.propTypes = {
+  namespace: PropTypes.string,
   schema: PropTypes.object,
   value: PropTypes.string,
   setField: PropTypes.func,
@@ -68,6 +70,7 @@ ChoiceInput.propTypes = {
 }
 
 ChoiceInput.defaultProps = {
+  namespace: '',
   value: '',
 }
 

--- a/src/js/components/select_input/SelectInput.js
+++ b/src/js/components/select_input/SelectInput.js
@@ -63,7 +63,11 @@ function SelectInput(props) {
     setField(serializeValue(newValue, { multiple, serialization }))
     if (action.action === 'create-option') {
       [opt].flat().forEach(newOpt => {
-        createOption({ fieldId: schema.id, option: newOpt })
+        createOption({
+          range: schema.config.options.range,
+          fieldId: schema.id,
+          option: newOpt,
+        })
       })
     }
   }
@@ -100,9 +104,12 @@ SelectInput.defaultProps = {
 
 function mapStateToProps(state, { schema }) {
   const requireFieldId = getFieldIdByKey(state, schema.config.requires)
+  const { config = {} } = schema
+  const { options = {} } = config
+  const range = options.range
   return {
-    loadedOptions: getFieldLoadedOptions(state, schema.id),
-    createdOptions: getFieldCreatedOptions(state, schema.id),
+    loadedOptions: getFieldLoadedOptions(state, range),
+    createdOptions: getFieldCreatedOptions(state, range),
     requireValue: getFieldValue(state, requireFieldId),
   }
 }

--- a/src/js/store/actions/__tests__/form.tests.js
+++ b/src/js/store/actions/__tests__/form.tests.js
@@ -449,17 +449,17 @@ describe('form', () => {
       expect(action.payload).toEqual(options.options)
     })
 
-    it('should include fieldId in action meta', () => {
+    it('should include range in action meta', () => {
       // GIVEN
       const options = {
-        fieldId: 1,
+        range: 'foo',
       }
 
       // WHEN
       const action = form.submitCreatedOptions(options)
 
       // THEN
-      expect(action.meta.fieldId).toEqual(options.fieldId)
+      expect(action.meta.range).toEqual(options.range)
     })
   })
 

--- a/src/js/store/actions/form.js
+++ b/src/js/store/actions/form.js
@@ -65,22 +65,22 @@ export const fetchOptions = ({ fieldId, range, requires, requireValue }) => ({
   meta: { fieldId, requires, requireValue, feature: FORM },
 })
 
-export const createOption = ({ fieldId, option }) => ({
+export const createOption = ({ range, fieldId, option }) => ({
   type: CREATE_OPTION,
   payload: option,
-  meta: { fieldId, feature: FORM },
+  meta: { range, fieldId, feature: FORM },
 })
 
-export const submitCreatedOptions = ({ fieldId, options }) => ({
+export const submitCreatedOptions = ({ range, options }) => ({
   type: SUBMIT_CREATED_OPTIONS,
   payload: options,
-  meta: { fieldId, feature: FORM },
+  meta: { range, feature: FORM },
 })
 
-export const setOptions = ({ fieldId, options }) => ({
+export const setOptions = ({ range, fieldId, options }) => ({
   type: SET_OPTIONS,
   payload: options,
-  meta: { fieldId, feature: FORM },
+  meta: { range, fieldId, feature: FORM },
 })
 
 export const loadIndex = () => ({

--- a/src/js/store/middleware/feature/form.js
+++ b/src/js/store/middleware/feature/form.js
@@ -93,7 +93,11 @@ const handleApiSuccess = (store, next, action) => {
       break
 
     case FETCH_OPTIONS:
-      next(setOptions({ fieldId: referrer.meta.fieldId, options: action.payload }))
+      next(setOptions({
+        range: referrer.payload,
+        fieldId: referrer.meta.fieldId,
+        options: action.payload,
+      }))
       break
 
     case SUBMIT:
@@ -143,12 +147,11 @@ const handleFetchOptions = (store, next, action) => {
 
 const handleSubmitCreatedOptions = (store, next, action) => {
   const state = store.getState()
-  const schema = getFieldSchema(state, action.meta.fieldId)
   next(apiRequest({
     body: JSON.stringify([action.payload.map(opt => opt.value)]),
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    url: submitURL(state.form.form, schema.config.options.range),
+    url: submitURL(state.form.form, action.meta.range),
     referrer: action,
     feature: FORM,
   }))
@@ -197,8 +200,8 @@ const handleSubmit = (store, next, action) => {
     const message = 'Correct errors before submission'
     return next(setErrorNotification({ message, feature: FORM }))
   }
-  Object.entries(state.form.options.created).forEach(([fieldId, options]) => {
-    store.dispatch(submitCreatedOptions({ fieldId, options }))
+  Object.entries(state.form.options.created).forEach(([range, options]) => {
+    store.dispatch(submitCreatedOptions({ range, options }))
   })
   const row = state.form.schema.columns
     .map(col => getFieldValue(state, col.id))

--- a/src/js/store/reducers/__tests__/form.tests.js
+++ b/src/js/store/reducers/__tests__/form.tests.js
@@ -97,14 +97,15 @@ describe('form', () => {
         // GIVEN
         const initial = form.formReducer(undefined, { type: '@@INIT' })
         const fieldId = 1
+        const range = 'foo'
         const options = [{ value: 'hello' }]
-        const action = actions.setOptions({ fieldId, options })
+        const action = actions.setOptions({ range, fieldId, options })
 
         // WHEN
         const newState = form.formReducer(initial, action)
 
         // THEN
-        expect(newState.options).toEqual({ loaded: {  [fieldId]: options }, created: {} })
+        expect(newState.options).toEqual({ loaded: {  [range]: options }, created: {} })
       })
     })
 
@@ -113,14 +114,15 @@ describe('form', () => {
         // GIVEN
         const initial = form.formReducer(undefined, { type: '@@INIT' })
         const fieldId = 1
+        const range = 'foo'
         const option = { value: 'hello' }
-        const action = actions.createOption({ fieldId, option })
+        const action = actions.createOption({ range, fieldId, option })
 
         // WHEN
         const newState = form.formReducer(initial, action)
 
         // THEN
-        expect(newState.options).toEqual({ loaded: {}, created: {  [fieldId]: [option] } })
+        expect(newState.options).toEqual({ loaded: {}, created: {  [range]: [option] } })
       })
     })
 

--- a/src/js/store/reducers/form.js
+++ b/src/js/store/reducers/form.js
@@ -58,7 +58,7 @@ const fieldErrorReducer = (errors = {}, action) => {
 const loadedOptionsReducer = (options = {}, action) => {
   switch (action.type) {
     case SET_OPTIONS:
-      return { ...options, [action.meta.fieldId]: action.payload }
+      return { ...options, [action.meta.range]: action.payload }
 
     case CLEAR:
       return {}
@@ -73,7 +73,7 @@ const createdOptionsReducer = (options = {}, action) => {
     case CREATE_OPTION:
       return {
         ...options,
-        [action.meta.fieldId]: [...(options[action.meta.fieldId] || []), action.payload],
+        [action.meta.range]: [...(options[action.meta.range] || []), action.payload],
       }
 
     case CLEAR:

--- a/src/js/store/selectors/form.js
+++ b/src/js/store/selectors/form.js
@@ -20,10 +20,10 @@ export const getFieldErrors = (state, fieldId) => {
   return state.form.errors[fieldId]
 }
 
-export const getFieldLoadedOptions = (state, fieldId) => {
-  return state.form.options.loaded[fieldId]
+export const getFieldLoadedOptions = (state, range) => {
+  return state.form.options.loaded[range]
 }
 
-export const getFieldCreatedOptions = (state, fieldId) => {
-  return state.form.options.created[fieldId]
+export const getFieldCreatedOptions = (state, range) => {
+  return state.form.options.created[range]
 }


### PR DESCRIPTION
* Allow name-spacing fields to uniquely name radio button inputs when multiple relative models are present
* Store options by `range` rather than `fieldId` to disambiguate options loaded for primary fields from options loaded for relative fields and to allow better option set reuse across fields