### PR TITLE
Fix multiple creatable select functionality and catch auth error

### DIFF
--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -69,9 +69,13 @@ const configure = (config) => {
       }
 
       const authToCheck = authIsCurrent(auth) ? auth : undefined
-      const userCanAccess = await storePlugin.userCanAccess(formId, authToCheck)
-      if (userCanAccess) return next()
-      next(new Error(`unauthorized access to resource ${formType}/${formId}`))
+      try {
+        const userCanAccess = await storePlugin.userCanAccess(formId, authToCheck)
+        if (userCanAccess) return next()
+      } catch(error) {
+        console.error(error)
+        next(new Error(`unauthorized access to resource ${formType}/${formId}`))
+      }
     }
   }
 

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -74,8 +74,8 @@ const configure = (config) => {
         if (userCanAccess) return next()
       } catch(error) {
         console.error(error)
-        next(new Error(`unauthorized access to resource ${formType}/${formId}`))
       }
+      next(new Error(`unauthorized access to resource ${formType}/${formId}`))
     }
   }
 

--- a/src/js/components/select_input/SelectInput.js
+++ b/src/js/components/select_input/SelectInput.js
@@ -49,6 +49,7 @@ function SelectInput(props) {
   if (optionlist) return <ChoiceInput {...props} />
 
   const options = [...(loadedOptions || []), ...(createdOptions || [])]
+  const optionsSet = new Set(options)
   const parsedValue = parseValue(value, { multiple, serialization })
 
   const getLabel = opt => opt.label || opt.value
@@ -63,6 +64,7 @@ function SelectInput(props) {
     setField(serializeValue(newValue, { multiple, serialization }))
     if (action.action === 'create-option') {
       [opt].flat().forEach(newOpt => {
+        if (optionsSet.has(newOpt)) return
         createOption({
           range: schema.config.options.range,
           fieldId: schema.id,

--- a/src/js/store/middleware/feature/__tests__/form.tests.js
+++ b/src/js/store/middleware/feature/__tests__/form.tests.js
@@ -154,7 +154,7 @@ describe('form', () => {
       const getState = () => state
       const next = jest.fn()
       const splitNext = actionSplitterMiddleware()(next)
-      const action = actions.submitCreatedOptions({ fieldId: 0, options: ['basic'] })
+      const action = actions.submitCreatedOptions({ fieldId: 0, options: [{ value: 'basic' }] })
 
       // WHEN
       form.formMiddleware({ getState })(splitNext)(action)
@@ -163,6 +163,43 @@ describe('form', () => {
       expect(next.mock.calls.length).toEqual(2)
       expect(next.mock.calls[0][0]).toEqual(action)
       expect(next.mock.calls[1][0].type).toMatch(apiActions.API_REQUEST)
+      expect(next.mock.calls[1][0].payload).toEqual(JSON.stringify([['basic']]))
+    })
+
+    it('should trigger API request on SUBMIT_CREATED_OPTIONS with multiple values as separate rows', () => {
+      // GIVEN
+      const state = {
+        form: {
+          form: {
+            type: 'd',
+            id: '12345',
+          },
+          schema: {
+            columns: [
+              { id: 0, label: 'Type', config: { options: { range: 'types' } } },
+            ],
+          },
+        },
+      }
+      const getState = () => state
+      const next = jest.fn()
+      const splitNext = actionSplitterMiddleware()(next)
+      const action = actions.submitCreatedOptions({
+        fieldId: 0,
+        options: [
+          { value: 'basic' },
+          { value: 'complex' },
+        ],
+      })
+
+      // WHEN
+      form.formMiddleware({ getState })(splitNext)(action)
+
+      // THEN
+      expect(next.mock.calls.length).toEqual(2)
+      expect(next.mock.calls[0][0]).toEqual(action)
+      expect(next.mock.calls[1][0].type).toMatch(apiActions.API_REQUEST)
+      expect(next.mock.calls[1][0].payload).toEqual(JSON.stringify([['basic'], ['complex']]))
     })
 
     describe('VALIDATE_FIELD', () => {

--- a/src/js/store/middleware/feature/form.js
+++ b/src/js/store/middleware/feature/form.js
@@ -148,7 +148,7 @@ const handleFetchOptions = (store, next, action) => {
 const handleSubmitCreatedOptions = (store, next, action) => {
   const state = store.getState()
   next(apiRequest({
-    body: JSON.stringify([action.payload.map(opt => opt.value)]),
+    body: JSON.stringify(action.payload.map(opt => [opt.value])),
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     url: submitURL(state.form.form, action.meta.range),


### PR DESCRIPTION
- Filter selected values on creation from select to avoid duplicating created values
- Correctly submit multiple single-value rows on submission rather than one row of the multiple created values
- Catch auth error during evaluation of permissions and serve error page (occurs when service account doesn't have adequate permissions to check user permissions on the sheet)