### PR TITLE
Add `layout` array to schema for non-input content

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "ISC",
   "sideEffects": false,
   "engines": {
-    "node": "12.x",
+    "node": ">=12.x",
     "yarn": "1.x"
   },
   "scripts": {
@@ -84,6 +84,7 @@
     "helmet": "^4.4.1",
     "http-proxy-middleware": "^1.0.6",
     "jsonwebtoken": "^8.5.1",
+    "marked": "^4.0.1",
     "mini-css-extract-plugin": "^0.9.0",
     "moment": "^2.29.1",
     "react": "^16.13.1",
@@ -94,6 +95,7 @@
     "react-redux": "^7.2.2",
     "react-select": "^3.1.0",
     "redux": "^4.0.5",
+    "sanitize-html": "^2.5.3",
     "styled-components": "^5.1.1"
   },
   "babel": {

--- a/server/stores/schema.js
+++ b/server/stores/schema.js
@@ -1,4 +1,6 @@
 const CSV = require('csv-string')
+const { marked } = require('marked')
+const sanitizeHtml = require('sanitize-html')
 
 function identity(x) {
   return x
@@ -98,6 +100,7 @@ function parseSchema(type, form, configs) {
       id: form,
       path: `/${type}/${form}`,
     },
+    layout: [],
   }
   for (let config of configs) {
     const [configType, ...cfg] = config.filter(c => c)
@@ -105,6 +108,7 @@ function parseSchema(type, form, configs) {
       schema.columns = schema.columns || []
       const column = parseColumnSchema(cfg, schema.columns.length)
       schema.columns.push(column)
+      schema.layout.push({ type: 'column', index: schema.columns.length - 1 })
     } else if (configType === 'relative_column') {
       schema.relatives = schema.relatives || {}
       const column = parseColumnSchema(cfg)
@@ -115,6 +119,12 @@ function parseSchema(type, form, configs) {
       const relativeCols = schema.relatives[column.relative]
       const id = relativeCols.length
       relativeCols.push({ ...column, id })
+    } else if (configType === 'text') {
+      const html = sanitizeHtml(marked(cfg[0] || ''))
+      schema.layout.push({ type: 'text', html })
+    } else if (configType === 'chatter') {
+      const html = sanitizeHtml(marked(cfg[0] || ''))
+      schema.chatter = html
     } else {
       schema[configType.toLowerCase()] = cfg[0]
     }

--- a/src/js/components/form/Form.js
+++ b/src/js/components/form/Form.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Controls, Field } from 'js/components'
+import { Controls, Field, TextBlock } from 'js/components'
 
 function Form(props) {
   const {
-    fields,
+    blocks,
+    columns,
     controls,
     values,
     errors,
@@ -12,19 +13,32 @@ function Form(props) {
     validateField,
   } = props
 
-  if (!fields) return null
+  if (!blocks || !columns) return null
+
+  function renderBlock(block) {
+    if (block.type === 'text') return (
+      <TextBlock dangerouslySetInnerHTML={{ __html: block.html }} />
+    )
+
+    const field = columns[block.index]
+    return (
+      <Field
+        key={field.id}
+        schema={field}
+        value={values[field.id]}
+        errors={errors[field.id]}
+        setField={value => setField({ fieldId: field.id, value })}
+        validateField={() => validateField({ fieldId: field.id })}
+      />
+    )
+  }
 
   return (
     <>
-      {fields.map(field => (
-        <Field
-          key={field.id}
-          schema={field}
-          value={values[field.id]}
-          errors={errors[field.id]}
-          setField={value => setField({ fieldId: field.id, value })}
-          validateField={() => validateField({ fieldId: field.id })}
-        />
+      {blocks.map((block, i) => (
+        <React.Fragment key={i}>
+          {renderBlock(block)}
+        </React.Fragment>
       ))}
       <Controls buttons={controls} />
     </>

--- a/src/js/components/header/Header.js
+++ b/src/js/components/header/Header.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { TextBlock } from 'js/components'
 import { TitleContainer, DownloadLink, DownloadIcon } from './styles'
 
 function Header(props) {
@@ -21,7 +22,7 @@ function Header(props) {
           </DownloadLink>
         </TitleContainer>
       )}
-      {chatter && <div>{chatter}</div>}
+      {chatter && <TextBlock dangerouslySetInnerHTML={{ __html: chatter }} />}
     </div>
   )
 }

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -20,6 +20,7 @@ import ErrorBoundary from './error_boundary'
 import LandingPage from './landing_page'
 import Footer from './footer'
 import Layout from './layout'
+import TextBlock from './text_block'
 
 export {
   App,
@@ -43,7 +44,8 @@ export {
   ErrorBoundary,
   LandingPage,
   Footer,
-  Layout
+  Layout,
+  TextBlock
 }
 
 export default App

--- a/src/js/components/text_block/TextBlock.js
+++ b/src/js/components/text_block/TextBlock.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+import { lightNeutral } from 'js/styles/colors'
+
+const TextBlock = styled.div`
+  p {
+    margin-block-start: 1em;
+    margin-block-end: 0em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+  }
+
+  hr {
+    border: none;
+    width: 100%;
+    max-width: 400px;
+    height: 4px;
+    margin: 2em auto;
+    background-color: ${lightNeutral};
+  }
+`
+
+export default TextBlock

--- a/src/js/components/text_block/index.js
+++ b/src/js/components/text_block/index.js
@@ -1,0 +1,3 @@
+import TextBlock from './TextBlock'
+
+export default TextBlock

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,9 +2600,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001181:
-  version "1.0.30001192"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz#b848ebc0ab230cf313d194a4775a30155d50ae40"
-  integrity sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==
+  version "1.0.30001280"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz"
+  integrity sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3627,6 +3627,15 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -3642,6 +3651,11 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
   integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
 
+domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -3656,6 +3670,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
+  integrity sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
+  dependencies:
+    domelementtype "^2.2.0"
+
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -3663,6 +3684,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.5.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -3922,6 +3952,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.14.1:
   version "1.14.3"
@@ -5185,6 +5220,16 @@ htmlparser2@^3.10.1:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
+htmlparser2@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
+
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -5702,6 +5747,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
@@ -6736,6 +6786,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+marked@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.1.tgz#eaec1f18ab3d5a071697cebe45e0ae4b2216a8f5"
+  integrity sha512-L90F6VQdYJSL1WVaIGCbNASAWnPCyB/jGmvQ/KIk0ThYq0XuzRrWxhwjcHoYvIZlQHKD/C/2i7DAADFPgxV7Tw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -7042,6 +7097,11 @@ nan@^2.12.1, nan@^2.13.2:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nanoid@^3.1.30:
+  version "3.1.30"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
+  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -7661,6 +7721,11 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=
+
 parse5@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
@@ -7784,6 +7849,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
@@ -8195,6 +8265,15 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.27, postcss@^7.0.3
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.3.11:
+  version "8.3.11"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
+  integrity sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==
+  dependencies:
+    nanoid "^3.1.30"
+    picocolors "^1.0.0"
+    source-map-js "^0.6.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -9012,6 +9091,18 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sanitize-html@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.5.3.tgz#91aa3dc760b072cdf92f9c6973747569b1ba1cd8"
+  integrity sha512-DGATXd1fs/Rm287/i5FBKVYSBBUL0iAaztOA1/RFhEs4yqo39/X52i/q/CwsfCUG5cilmXSBmnQmyWfnKhBlOg==
+  dependencies:
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^6.0.0"
+    is-plain-object "^5.0.0"
+    parse-srcset "^1.0.2"
+    postcss "^8.3.11"
+
 sass-graph@2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.5.tgz#a981c87446b8319d96dce0671e487879bd24c2e8"
@@ -9365,6 +9456,11 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"


### PR DESCRIPTION
Support a new type of configuration row called `text` that takes whatever text is in the second column, parses it as markdown, sanitizes the resulting HTML, and then renders it on the page interleaved with form inputs. Note that any columns that are part of the `index` still get hoisted to the top of the form.

Parse chatter as markdown and render it as HTML. Chatter is still rendered before the index entry, so it can be used as free-form text content before the index entry fields.

Example of chatter and text fields being rendered with no index set:

![Screen Shot 2021-11-12 at 2 43 09 PM](https://user-images.githubusercontent.com/20450153/141588393-7494e5ec-d22b-4f86-9c16-d7d2c8dc395d.png)

Example of chatter and text fields being rendered with index field getting hoisted to top:

![Screen Shot 2021-11-12 at 2 43 48 PM](https://user-images.githubusercontent.com/20450153/141588623-f706151b-a14e-4191-8d9a-504cb7d47fa4.png)

Schema from the example with the index set (same as for first example, only difference is the addition of the index configuration):

![Screen Shot 2021-11-12 at 2 55 49 PM](https://user-images.githubusercontent.com/20450153/141588841-9c51cff4-c5f0-4202-9b07-7be4350bd7b6.png)
