### PR TITLE
Compare lower-cased emails to verify authorization

### DIFF
--- a/server/stores/google-sheets/google.js
+++ b/server/stores/google-sheets/google.js
@@ -34,7 +34,7 @@ async function emailCanRead(fileId, email) {
   const filePermissions = await drive.permissions.list(request)
   return filePermissions.data.permissions.some(perm => {
     if (perm.id === 'anyoneWithLink') return true
-    return perm.emailAddress === email
+    return perm.emailAddress.toLowerCase() === email.toLowerCase()
   })
 }
 


### PR DESCRIPTION
Google OAuth and Drive permissions can include case-inconsistencies, so relax the email check to ignore case