### PR TITLE
Persist unsubmitted inputs in local storage for work recovery

### DIFF
--- a/src/js/components/app/App.js
+++ b/src/js/components/app/App.js
@@ -1,7 +1,17 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { fetchSchema, submit, clear, loadIndex, inputField, setField, validateField } from 'js/store/actions/form'
+import {
+  fetchSchema,
+  submit,
+  clear,
+  loadIndex,
+  inputField,
+  setField,
+  validateField,
+  acceptLocalStorage,
+  rejectLocalStorage
+} from 'js/store/actions/form'
 import { setUser } from 'js/store/actions/user'
 import { Layout, Header, Notifications, Form, Finished, ErrorBoundary } from 'js/components'
 import { getNotifications } from 'js/store/selectors/notification'
@@ -29,6 +39,9 @@ function App(props) {
     validateField,
     clear,
     setUser,
+    askingToRestore,
+    acceptLocalStorage,
+    rejectLocalStorage,
   } = props
 
   useEffect(() => { setUser({ email: user && user.email }) }, []) // eslint-disable-line react-hooks/exhaustive-deps
@@ -36,6 +49,16 @@ function App(props) {
   useEffect(() => {
     window.onbeforeunload = () => dirty ? true : undefined
   }, [dirty])
+
+  useEffect(() => {
+    if (!askingToRestore) return
+    const msg = 'You have some unsubmitted data for this form. Would you like to pick up where you left off?'
+    if (confirm(msg)) {
+      acceptLocalStorage()
+    } else {
+      rejectLocalStorage()
+    }
+  }, [askingToRestore])
 
   const { index, columns = [], layout = [] } = schema
   const indexKeys = index && index.split('+')
@@ -163,7 +186,19 @@ function mapStateToProps(state) {
     dirty: state.ui.formDirty,
     indexLoaded: state.ui.indexLoaded,
     finished: state.ui.finished,
+    askingToRestore: state.ui.askingToRestore,
   }
 }
 
-export default connect(mapStateToProps, { fetchSchema, submit, clear, loadIndex, setField, inputField, validateField, setUser })(App)
+export default connect(mapStateToProps, {
+  fetchSchema,
+  submit,
+  clear,
+  loadIndex,
+  setField,
+  inputField,
+  validateField,
+  setUser,
+  acceptLocalStorage,
+  rejectLocalStorage,
+})(App)

--- a/src/js/store/actions/form.js
+++ b/src/js/store/actions/form.js
@@ -16,6 +16,8 @@ export const SET_OPTIONS = `${FORM} SET_OPTIONS`
 export const LOAD_INDEX = `${FORM} LOAD_INDEX`
 export const SUBMIT = `${FORM} SUBMIT`
 export const CLEAR = `${FORM} CLEAR`
+export const PERSIST_IN_LOCAL_STORAGE = `${FORM} PERSIST_IN_LOCAL_STORAGE`
+export const CLEAR_LOCAL_STORAGE = `${FORM} CLEAR_LOCAL_STORAGE`
 
 // action creators
 export const fetchSchema = ({ type, id }) => ({
@@ -95,5 +97,15 @@ export const submit = () => ({
 
 export const clear = () => ({
   type: CLEAR,
+  meta: { feature: FORM },
+})
+
+export const persistInLocalStorage = () => ({
+  type: PERSIST_IN_LOCAL_STORAGE,
+  meta: { feature: FORM },
+})
+
+export const clearLocalStorage = () => ({
+  type: CLEAR_LOCAL_STORAGE,
   meta: { feature: FORM },
 })

--- a/src/js/store/actions/form.js
+++ b/src/js/store/actions/form.js
@@ -18,6 +18,8 @@ export const SUBMIT = `${FORM} SUBMIT`
 export const CLEAR = `${FORM} CLEAR`
 export const PERSIST_IN_LOCAL_STORAGE = `${FORM} PERSIST_IN_LOCAL_STORAGE`
 export const CLEAR_LOCAL_STORAGE = `${FORM} CLEAR_LOCAL_STORAGE`
+export const REJECT_LOCAL_STORAGE = `${FORM} REJECT_LOCAL_STORAGE`
+export const ACCEPT_LOCAL_STORAGE = `${FORM} ACCEPT_LOCAL_STORAGE`
 
 // action creators
 export const fetchSchema = ({ type, id }) => ({
@@ -107,5 +109,15 @@ export const persistInLocalStorage = () => ({
 
 export const clearLocalStorage = () => ({
   type: CLEAR_LOCAL_STORAGE,
+  meta: { feature: FORM },
+})
+
+export const rejectLocalStorage = () => ({
+  type: REJECT_LOCAL_STORAGE,
+  meta: { feature: FORM },
+})
+
+export const acceptLocalStorage = () => ({
+  type: ACCEPT_LOCAL_STORAGE,
   meta: { feature: FORM },
 })

--- a/src/js/store/actions/ui.js
+++ b/src/js/store/actions/ui.js
@@ -5,6 +5,7 @@ export const SET_FORM_DIRTY = 'SET_FORM_DIRTY'
 export const SET_FORM_READY = 'SET_FORM_READY'
 export const SET_INDEX_LOADED = 'SET_INDEX_LOADED'
 export const SET_FINISHED = 'SET_FINISHED'
+export const SET_ASKING_TO_RESTORE = 'SET_ASKING_TO_RESTORE'
 
 // action creators
 export const setLoader = ({ state, feature }) => ({
@@ -39,6 +40,12 @@ export const setIndexLoaded = ({ state, feature }) => ({
 
 export const setFinished = ({ state, feature }) => ({
   type: `${feature} ${SET_FINISHED}`,
+  payload: state,
+  meta: { feature },
+})
+
+export const setAskingToRestore = ({ state, feature }) => ({
+  type: `${feature} ${SET_ASKING_TO_RESTORE}`,
   payload: state,
   meta: { feature },
 })

--- a/src/js/store/middleware/feature/__tests__/form.tests.js
+++ b/src/js/store/middleware/feature/__tests__/form.tests.js
@@ -63,7 +63,7 @@ describe('form', () => {
       expect(next.mock.calls[2][0].payload).toBe(false)
     })
 
-    it('should set form dirty and dispatch set field on INPUT_FIELD', () => {
+    it('should set form dirty, dispatch set field, and persist in local storage on INPUT_FIELD', () => {
       // GIVEN
       const dispatch = jest.fn()
       const next = jest.fn()
@@ -78,10 +78,11 @@ describe('form', () => {
       expect(next.mock.calls[0][0]).toEqual(action)
       expect(next.mock.calls[1][0].type).toMatch(uiActions.SET_FORM_DIRTY)
       expect(next.mock.calls[1][0].payload).toBe(true)
-      expect(dispatch.mock.calls.length).toEqual(1)
+      expect(dispatch.mock.calls.length).toEqual(2)
       expect(dispatch.mock.calls[0][0].type).toEqual(actions.SET_FIELD)
       expect(dispatch.mock.calls[0][0].payload).toEqual(action.payload)
       expect(dispatch.mock.calls[0][0].meta.fieldId).toEqual(action.meta.fieldId)
+      expect(dispatch.mock.calls[1][0].type).toEqual(actions.PERSIST_IN_LOCAL_STORAGE)
     })
 
     it('should set requires to null on SET_FIELD', () => {
@@ -444,7 +445,7 @@ describe('form', () => {
     })
 
     describe('CLEAR', () => {
-      it('should reset UI state on CLEAR resetting index if index set', () => {
+      it('should clear local storage and reset UI state on CLEAR resetting index if index set', () => {
         // GIVEN
         const state = {
           form: {
@@ -454,21 +455,24 @@ describe('form', () => {
           },
         }
         const getState = () => state
+        const dispatch = jest.fn()
         const next = jest.fn()
         const splitNext = actionSplitterMiddleware()(next)
         const action = actions.clear()
 
         // WHEN
-        form.formMiddleware({ getState })(splitNext)(action)
+        form.formMiddleware({ getState, dispatch })(splitNext)(action)
 
         // THEN
         expect(next.mock.calls.length).toEqual(3)
         expect(next.mock.calls[0][0]).toEqual(action)
         expect(next.mock.calls[1][0]).toEqual(uiActions.setFormDirty({ state: false, feature: actions.FORM }))
         expect(next.mock.calls[2][0]).toEqual(uiActions.setIndexLoaded({ state: false, feature: actions.FORM }))
+        expect(dispatch.mock.calls.length).toEqual(1)
+        expect(dispatch.mock.calls[0][0].type).toEqual(actions.CLEAR_LOCAL_STORAGE)
       })
 
-      it('should reset UI state on CLEAR not resetting index if no index set', () => {
+      it('should clear local storage and reset UI state on CLEAR not resetting index if no index set', () => {
         // GIVEN
         const state = {
           form: {
@@ -476,18 +480,21 @@ describe('form', () => {
           },
         }
         const getState = () => state
+        const dispatch = jest.fn()
         const next = jest.fn()
         const splitNext = actionSplitterMiddleware()(next)
         const action = actions.clear()
 
         // WHEN
-        form.formMiddleware({ getState })(splitNext)(action)
+        form.formMiddleware({ getState, dispatch })(splitNext)(action)
 
         // THEN
         expect(next.mock.calls.length).toEqual(3)
         expect(next.mock.calls[0][0]).toEqual(action)
         expect(next.mock.calls[1][0]).toEqual(uiActions.setFormDirty({ state: false, feature: actions.FORM }))
         expect(next.mock.calls[2][0]).toEqual(uiActions.setIndexLoaded({ state: true, feature: actions.FORM }))
+        expect(dispatch.mock.calls.length).toEqual(1)
+        expect(dispatch.mock.calls[0][0].type).toEqual(actions.CLEAR_LOCAL_STORAGE)
       })
     })
   })

--- a/src/js/store/middleware/feature/form.js
+++ b/src/js/store/middleware/feature/form.js
@@ -271,6 +271,7 @@ const handlePersistInLocalStorage = (store) => {
   const storageState = {
     schema: state.form.schema,
     fields: state.form.fields,
+    ui: state.ui,
   }
   window.localStorage.setItem(key, JSON.stringify(storageState))
 }
@@ -284,7 +285,7 @@ const handleClearLocalStorage = (store) => {
 const handleAcceptLocalStorage = (store, next) => {
   const state = store.getState()
   const key = localStorageKey(state)
-  let storageState = { fields: {} }
+  let storageState = { ui: {}, fields: {} }
   try {
     storageState = JSON.parse(window.localStorage.getItem(key))
   } catch(error) {
@@ -293,6 +294,9 @@ const handleAcceptLocalStorage = (store, next) => {
   Object.entries(storageState.fields).forEach(([fieldId, value]) => {
     store.dispatch(inputField({ fieldId, value }))
   })
+  if (storageState.ui.indexLoaded) {
+    next(setIndexLoaded({ state: true, feature: FORM }))
+  }
   next(setAskingToRestore({ state: false, feature: FORM }))
 }
 

--- a/src/js/store/reducers/ui.js
+++ b/src/js/store/reducers/ui.js
@@ -4,7 +4,8 @@ import {
   SET_FORM_DIRTY,
   SET_FORM_READY,
   SET_INDEX_LOADED,
-  SET_FINISHED
+  SET_FINISHED,
+  SET_ASKING_TO_RESTORE
 } from '../actions/ui'
 
 const initState = {
@@ -14,6 +15,7 @@ const initState = {
   formReady: false,
   indexLoaded: false,
   finished: false,
+  askingToRestore: false,
 }
 
 export const uiReducer = (ui = initState, action) => {
@@ -35,6 +37,9 @@ export const uiReducer = (ui = initState, action) => {
 
     case action.type.includes(SET_FINISHED):
       return { ...ui, finished: action.payload }
+
+    case action.type.includes(SET_ASKING_TO_RESTORE):
+      return { ...ui, askingToRestore: action.payload }
 
     default:
       return ui


### PR DESCRIPTION
- Store form schema and inputted field values in local storage keyed by form type and ID
- On form schema load, check for existing data in local storage for this form. If it's there and the schema has not changed in the meantime, ask the user if they want to pick up where they left off.
  - If the user accepts their old data, load the field values from local storage
  - If the user rejects their old data, clear the stored data in local storage and start with a clean form like usual
- When the user submits the form successfully, clear the data in local storage for this form