### PR TITLE
Wait for form submission success before submitting created options

### DIFF
--- a/src/js/store/middleware/feature/__tests__/form.tests.js
+++ b/src/js/store/middleware/feature/__tests__/form.tests.js
@@ -362,7 +362,7 @@ describe('form', () => {
     })
 
     describe('SUBMIT', () => {
-      it('should validate form, trigger API request, and submit created options on SUBMIT', () => {
+      it('should validate form and trigger API request', () => {
         // GIVEN
         const state = {
           user: {},
@@ -399,9 +399,8 @@ describe('form', () => {
         form.formMiddleware({ getState, dispatch })(splitNext)(action)
 
         // THEN
-        expect(dispatch.mock.calls.length).toEqual(2)
+        expect(dispatch.mock.calls.length).toEqual(1)
         expect(dispatch.mock.calls[0][0].type).toEqual(actions.VALIDATE_FORM)
-        expect(dispatch.mock.calls[1][0].type).toEqual(actions.SUBMIT_CREATED_OPTIONS)
         expect(next.mock.calls.length).toEqual(2)
         expect(next.mock.calls[0][0]).toEqual(action)
         expect(next.mock.calls[1][0].type).toMatch(apiActions.API_REQUEST)

--- a/src/js/store/middleware/feature/form.js
+++ b/src/js/store/middleware/feature/form.js
@@ -80,6 +80,22 @@ const handleLoadIndexResponse = (store, next, action) => {
   next(setIndexLoaded({ state: true, feature: FORM }))
 }
 
+const handleFormSubmissionSuccess = (store, next, action) => {
+  const state = store.getState()
+
+  // Submit created options
+  Object.entries(state.form.options.created).forEach(([range, options]) => {
+    store.dispatch(submitCreatedOptions({ range, options }))
+  })
+
+  // Clear form and notify success
+  store.dispatch(clear())
+  next([
+    setNotification({ message: 'Form submission successful', feature: FORM }),
+    setFinished({ state: true, feature: FORM }),
+  ])
+}
+
 const handleApiSuccess = (store, next, action) => {
   const { referrer } = action.meta
 
@@ -101,11 +117,7 @@ const handleApiSuccess = (store, next, action) => {
       break
 
     case SUBMIT:
-      store.dispatch(clear())
-      next([
-        setNotification({ message: 'Form submission successful', feature: FORM }),
-        setFinished({ state: true, feature: FORM }),
-      ])
+      handleFormSubmissionSuccess(store, next, action)
       break
 
     case LOAD_INDEX:
@@ -200,9 +212,6 @@ const handleSubmit = (store, next, action) => {
     const message = 'Correct errors before submission'
     return next(setErrorNotification({ message, feature: FORM }))
   }
-  Object.entries(state.form.options.created).forEach(([range, options]) => {
-    store.dispatch(submitCreatedOptions({ range, options }))
-  })
   const row = state.form.schema.columns
     .map(col => getFieldValue(state, col.id))
   const now = new Date()


### PR DESCRIPTION
Wait until the form submission request has completed successfully before submitting created options for future inclusion. This will prevent simultaneous requests messing with authentication refreshing and will also ensure that the new options only get created once the form entry has been accepted