### PR TITLE
Removing dyno specification in deploy button

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,7 +42,7 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "free"
+      "size": "eco"
     }
   },
   "buildpacks": [

--- a/app.json
+++ b/app.json
@@ -39,12 +39,6 @@
       "generator": "secret"
     }
   },
-  "formation": {
-    "web": {
-      "quantity": 1,
-      "size": "eco"
-    }
-  },
   "buildpacks": [
     {
       "url": "heroku/nodejs"


### PR DESCRIPTION
Current `app.json` file specifies the free Heroku dyno in the [formation variable](https://devcenter.heroku.com/articles/app-json-schema#formation), which no longer exists after Heroku discontinued its free tier. This causes deployment to fail.

This update removes the specification from the json file, which then defaults to whatever dyno the user is signed up for with Heroku.